### PR TITLE
feat(get-release): allow multiple owners

### DIFF
--- a/get-release/action.yml
+++ b/get-release/action.yml
@@ -2,11 +2,11 @@ name: 'Download GitHub Release'
 description: 'Download Github Release'
 inputs: 
   owner:
-    description: 'GitHub owner name (user/organization)'
+    description: 'GitHub owner name (user/organization - several owners can be given separated by a ";")'
     default: 'Geode-solutions'
     requiered: false
   repository:
-    description: 'GitHub repository name'
+    description: 'GitHub repository name (several repos can be given separated by a ";")'
     required: true
   file:
     description: 'regex of the file to download'

--- a/get-release/index.js
+++ b/get-release/index.js
@@ -8,16 +8,23 @@ const tar = require('tar');
 
 try {
   const repos = core.getInput('repository');
+  const owners = core.getInput('owner');
   if (repos.length) {
     let results = [];
-    const owner = core.getInput('owner', {required: true});
     const file = core.getInput('file', {required: true});
     const version = core.getInput('version');
     const token = core.getInput('token');
     const octokit = new Octokit({auth: token});
-    repos.split(';').forEach(repo => {
+    const array_repos = repos.split(';')
+    const array_owners = owners.split(';')
+    for (let itr = 0; itr < array_repos.length; itr++){
+      const repo = array_repos[itr]
+      owner = array_owners[itr]
       if (!repo.length) {
         return;
+      }
+      if(!owner.length){
+        owner = array_owners[0]
       }
       let promise = new Promise(function(resolve) {
         console.log('Looking for repository:', repo);


### PR DESCRIPTION
User can provide a list of owners with the list of repository. 
Each repository can have a different owner.
If all repositories belong to the same owner the information can be given only once.
The default value is still Geode-solution. 